### PR TITLE
feat(storage): add content_filters to DynamoDbChatStorage

### DIFF
--- a/docs/src/content/docs/storage/dynamodb.mdx
+++ b/docs/src/content/docs/storage/dynamodb.mdx
@@ -70,6 +70,29 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Ensure your AWS credentials are properly set up and that your application has the necessary permissions to access the DynamoDB table.
 
+### Content Filters (Python)
+
+The Python `DynamoDbChatStorage` accepts an optional `content_filters` parameter — a list of `(original, placeholder)` string pairs. Before a message is written to DynamoDB, every occurrence of `original` in its content is replaced with the corresponding `placeholder`. On every read path (`fetch_chat`, `fetch_chat_with_timestamp`, `fetch_all_chats`, and the value returned by `save_chat_message`/`save_chat_messages`), the placeholders are substituted back with their original values before the messages are handed back to your application.
+
+This lets you avoid storing sensitive strings (company names, tokens, PII, etc.) verbatim in DynamoDB while keeping the original values transparent to the rest of your application.
+
+```python
+from agent_squad.storage import DynamoDbChatStorage
+
+dynamodb_storage = DynamoDbChatStorage(
+    table_name='YourDynamoDBTableName',
+    region='your-aws-region',
+    content_filters=[
+        ('acme-corp', '#COMPANY#'),
+        ('secret-token-xyz', '#TOKEN#'),
+    ],
+)
+```
+
+- Filters are applied in list order, both when masking on save and when restoring on fetch.
+- If `content_filters` is omitted (or empty), behavior is unchanged from previous versions.
+- Filtering applies uniformly across all read paths, regardless of whether stored message content is a list of content blocks or a plain string.
+
 ## Considerations
 
 - Requires AWS account and proper IAM permissions

--- a/python/src/agent_squad/storage/dynamodb_chat_storage.py
+++ b/python/src/agent_squad/storage/dynamodb_chat_storage.py
@@ -1,4 +1,5 @@
 from typing import Union, Optional
+import json
 import time
 import boto3
 from agent_squad.storage import ChatStorage
@@ -13,14 +14,48 @@ class DynamoDbChatStorage(ChatStorage):
                  table_name: str,
                  region: str,
                  ttl_key: Optional[str] = None,
-                 ttl_duration: int = 3600):
+                 ttl_duration: int = 3600,
+                 content_filters: Optional[list[tuple[str, str]]] = None):
         super().__init__()
         self.table_name = table_name
         self.ttl_key = ttl_key
         self.ttl_duration = int(ttl_duration)
+        self.content_filters = content_filters or []
         self.dynamodb = boto3.resource('dynamodb', region_name=region)
         self.table = self.dynamodb.Table(table_name)
         user_agent.register_feature_to_resource(self.dynamodb, feature='storage-ddb')
+
+    def _apply_content_filters(self, content: list) -> list:
+        if not self.content_filters:
+            return content
+        serialized = json.dumps(content)
+        for original, placeholder in self.content_filters:
+            serialized = serialized.replace(original, placeholder)
+        return json.loads(serialized)
+
+    def _reverse_content_filters(self, content: list) -> list:
+        if not self.content_filters:
+            return content
+        serialized = json.dumps(content)
+        for original, placeholder in self.content_filters:
+            serialized = serialized.replace(placeholder, original)
+        return json.loads(serialized)
+
+    async def _fetch_raw(
+        self,
+        user_id: str,
+        session_id: str,
+        agent_id: str
+    ) -> list[TimestampedMessage]:
+        key = self._generate_key(user_id, session_id, agent_id)
+        try:
+            response = self.table.get_item(Key={'PK': user_id, 'SK': key})
+            return self._dict_to_conversation(
+                response.get('Item', {}).get('conversation', [])
+            )
+        except Exception as error:
+            Logger.error(f"Error getting conversation from DynamoDB: {str(error)}")
+            raise error
 
     async def save_chat_message(
         self,
@@ -31,7 +66,7 @@ class DynamoDbChatStorage(ChatStorage):
         max_history_size: Optional[int] = None
     ) -> list[ConversationMessage]:
         key = self._generate_key(user_id, session_id, agent_id)
-        existing_conversation = await self.fetch_chat_with_timestamp(user_id, session_id, agent_id)
+        existing_conversation = await self._fetch_raw(user_id, session_id, agent_id)
 
         if self.is_same_role_as_last_message(existing_conversation, new_message):
             Logger.debug(f"> Consecutive {new_message.role} \
@@ -41,7 +76,12 @@ class DynamoDbChatStorage(ChatStorage):
         if isinstance(new_message, ConversationMessage):
             new_message = TimestampedMessage(
                 role=new_message.role,
-                content=new_message.content)
+                content=self._apply_content_filters(new_message.content))
+        elif self.content_filters:
+            new_message = TimestampedMessage(
+                role=new_message.role,
+                content=self._apply_content_filters(new_message.content),
+                timestamp=new_message.timestamp)
 
         existing_conversation.append(new_message)
 
@@ -65,7 +105,10 @@ class DynamoDbChatStorage(ChatStorage):
             Logger.error(f"Error saving conversation to DynamoDB:{str(error)}")
             raise error
 
-        return self._remove_timestamps(trimmed_conversation)
+        return [ConversationMessage(
+            role=msg.role,
+            content=self._reverse_content_filters(msg.content)
+        ) for msg in trimmed_conversation]
 
     async def save_chat_messages(self,
         user_id: str,
@@ -79,7 +122,7 @@ class DynamoDbChatStorage(ChatStorage):
         Save multiple messages at once
         """
         key = self._generate_key(user_id, session_id, agent_id)
-        existing_conversation = await self.fetch_chat_with_timestamp(user_id, session_id, agent_id)
+        existing_conversation = await self._fetch_raw(user_id, session_id, agent_id)
 
         #TODO: check messages are consecutive
         # if self.is_same_role_as_last_message(existing_conversation, new_messages):
@@ -91,7 +134,15 @@ class DynamoDbChatStorage(ChatStorage):
             new_messages = [
                 TimestampedMessage(
                     role=new_message.role,
-                    content=new_message.content
+                    content=self._apply_content_filters(new_message.content)
+                )
+             for new_message in new_messages]
+        elif self.content_filters:
+            new_messages = [
+                TimestampedMessage(
+                    role=new_message.role,
+                    content=self._apply_content_filters(new_message.content),
+                    timestamp=new_message.timestamp
                 )
              for new_message in new_messages]
 
@@ -117,7 +168,10 @@ class DynamoDbChatStorage(ChatStorage):
             Logger.error(f"Error saving conversation to DynamoDB:{str(error)}")
             raise error
 
-        return self._remove_timestamps(trimmed_conversation)
+        return [ConversationMessage(
+            role=msg.role,
+            content=self._reverse_content_filters(msg.content)
+        ) for msg in trimmed_conversation]
 
     async def fetch_chat(
         self,
@@ -125,13 +179,12 @@ class DynamoDbChatStorage(ChatStorage):
         session_id: str,
         agent_id: str
     ) -> list[ConversationMessage]:
-        key = self._generate_key(user_id, session_id, agent_id)
         try:
-            response = self.table.get_item(Key={'PK': user_id, 'SK': key})
-            stored_messages: list[TimestampedMessage] = self._dict_to_conversation(
-                response.get('Item', {}).get('conversation', [])
-            )
-            return self._remove_timestamps(stored_messages)
+            stored_messages = await self._fetch_raw(user_id, session_id, agent_id)
+            return [ConversationMessage(
+                role=msg.role,
+                content=self._reverse_content_filters(msg.content)
+            ) for msg in stored_messages]
         except Exception as error:
             Logger.error(f"Error getting conversation from DynamoDB:{str(error)}")
             raise error
@@ -142,13 +195,15 @@ class DynamoDbChatStorage(ChatStorage):
         session_id: str,
         agent_id: str
     ) -> list[TimestampedMessage]:
-        key = self._generate_key(user_id, session_id, agent_id)
         try:
-            response = self.table.get_item(Key={'PK': user_id, 'SK': key})
-            stored_messages: list[TimestampedMessage] = self._dict_to_conversation(
-                response.get('Item', {}).get('conversation', [])
-            )
-            return stored_messages
+            stored_messages = await self._fetch_raw(user_id, session_id, agent_id)
+            if not self.content_filters:
+                return stored_messages
+            return [TimestampedMessage(
+                role=msg.role,
+                content=self._reverse_content_filters(msg.content),
+                timestamp=msg.timestamp
+            ) for msg in stored_messages]
         except Exception as error:
             Logger.error(f"Error getting conversation from DynamoDB: {str(error)}")
             raise error
@@ -174,7 +229,8 @@ class DynamoDbChatStorage(ChatStorage):
 
                 agent_id = item['SK'].split('#')[1]
                 for msg in item['conversation']:
-                    content = msg['content']
+                    content = self._reverse_content_filters(msg['content']) \
+                        if isinstance(msg['content'], list) else msg['content']
                     if msg['role'] == ParticipantRole.ASSISTANT.value:
                         text = content[0]['text'] if isinstance(content, list) else content
                         content = [{'text': f"[{agent_id}] {text}"}]

--- a/python/src/agent_squad/storage/dynamodb_chat_storage.py
+++ b/python/src/agent_squad/storage/dynamodb_chat_storage.py
@@ -71,7 +71,10 @@ class DynamoDbChatStorage(ChatStorage):
         if self.is_same_role_as_last_message(existing_conversation, new_message):
             Logger.debug(f"> Consecutive {new_message.role} \
                           message detected for agent {agent_id}. Not saving.")
-            return existing_conversation
+            return [ConversationMessage(
+                role=msg.role,
+                content=self._reverse_content_filters(msg.content)
+            ) for msg in existing_conversation]
 
         if isinstance(new_message, ConversationMessage):
             new_message = TimestampedMessage(
@@ -229,8 +232,7 @@ class DynamoDbChatStorage(ChatStorage):
 
                 agent_id = item['SK'].split('#')[1]
                 for msg in item['conversation']:
-                    content = self._reverse_content_filters(msg['content']) \
-                        if isinstance(msg['content'], list) else msg['content']
+                    content = self._reverse_content_filters(msg['content'])
                     if msg['role'] == ParticipantRole.ASSISTANT.value:
                         text = content[0]['text'] if isinstance(content, list) else content
                         content = [{'text': f"[{agent_id}] {text}"}]

--- a/python/src/tests/storage/test_dynamodb_chat_storage.py
+++ b/python/src/tests/storage/test_dynamodb_chat_storage.py
@@ -27,6 +27,14 @@ def dynamodb_table():
 def chat_storage(dynamodb_table):
     return DynamoDbChatStorage(table_name='test_table', region='us-east-1', ttl_key='TTL', ttl_duration=3600)
 
+@pytest.fixture
+def filtered_chat_storage(dynamodb_table):
+    return DynamoDbChatStorage(
+        table_name='test_table',
+        region='us-east-1',
+        content_filters=[('acme-corp', '#COMPANY#'), ('secret-token-xyz', '#TOKEN#')]
+    )
+
 @pytest.mark.asyncio
 async def test_save_and_fetch_chat_message(chat_storage):
     user_id = 'user1'
@@ -142,6 +150,103 @@ async def test_save_and_fetch_chat_messages(chat_storage):
     assert fetched_messages[3].role == ParticipantRole.ASSISTANT.value
     assert fetched_messages[4].content == [{'text': 'Message 4'}]
     assert fetched_messages[4].role == ParticipantRole.USER.value
+
+
+@pytest.mark.asyncio
+async def test_content_filters_replace_on_save_and_restore_on_fetch(filtered_chat_storage):
+    """Sensitive values should be stored as placeholders and restored on fetch."""
+    user_id = 'user1'
+    session_id = 'session1'
+    agent_id = 'agent1'
+    message = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{'text': 'Hello from acme-corp'}]
+    )
+
+    await filtered_chat_storage.save_chat_message(user_id, session_id, agent_id, message)
+
+    # Verify placeholder is stored in DynamoDB
+    raw = filtered_chat_storage.table.get_item(
+        Key={'PK': user_id, 'SK': filtered_chat_storage._generate_key(user_id, session_id, agent_id)}
+    )
+    stored_text = raw['Item']['conversation'][0]['content'][0]['text']
+    assert stored_text == 'Hello from #COMPANY#'
+
+    # Verify original value is returned by fetch_chat
+    fetched = await filtered_chat_storage.fetch_chat(user_id, session_id, agent_id)
+    assert fetched[0].content == [{'text': 'Hello from acme-corp'}]
+
+
+@pytest.mark.asyncio
+async def test_content_filters_fetch_chat_with_timestamp(filtered_chat_storage):
+    """fetch_chat_with_timestamp must also restore original values."""
+    user_id = 'user1'
+    session_id = 'session1'
+    agent_id = 'agent1'
+    message = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{'text': 'token: secret-token-xyz'}]
+    )
+
+    await filtered_chat_storage.save_chat_message(user_id, session_id, agent_id, message)
+
+    fetched = await filtered_chat_storage.fetch_chat_with_timestamp(user_id, session_id, agent_id)
+    assert fetched[0].content == [{'text': 'token: secret-token-xyz'}]
+    assert isinstance(fetched[0].timestamp, Decimal)
+
+
+@pytest.mark.asyncio
+async def test_content_filters_multiple_filters_round_trip(filtered_chat_storage):
+    """Multiple filters should all be applied and reversed correctly."""
+    user_id = 'user1'
+    session_id = 'session1'
+    agent_id = 'agent1'
+
+    msg1 = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{'text': 'Company acme-corp uses secret-token-xyz'}]
+    )
+    msg2 = ConversationMessage(
+        role=ParticipantRole.ASSISTANT.value,
+        content=[{'text': 'Confirmed for acme-corp'}]
+    )
+
+    await filtered_chat_storage.save_chat_message(user_id, session_id, agent_id, msg1)
+    await filtered_chat_storage.save_chat_message(user_id, session_id, agent_id, msg2)
+
+    fetched = await filtered_chat_storage.fetch_chat(user_id, session_id, agent_id)
+    assert fetched[0].content == [{'text': 'Company acme-corp uses secret-token-xyz'}]
+    assert fetched[1].content == [{'text': 'Confirmed for acme-corp'}]
+
+
+@pytest.mark.asyncio
+async def test_content_filters_save_chat_messages(filtered_chat_storage):
+    """save_chat_messages should also apply content filters."""
+    messages = [
+        ConversationMessage(role=ParticipantRole.USER.value, content=[{'text': 'acme-corp question'}]),
+        ConversationMessage(role=ParticipantRole.ASSISTANT.value, content=[{'text': 'acme-corp answer'}]),
+    ]
+
+    await filtered_chat_storage.save_chat_messages('user1', 'session1', 'agent1', messages)
+    fetched = await filtered_chat_storage.fetch_chat('user1', 'session1', 'agent1')
+
+    assert fetched[0].content == [{'text': 'acme-corp question'}]
+    assert fetched[1].content == [{'text': 'acme-corp answer'}]
+
+
+@pytest.mark.asyncio
+async def test_no_content_filters_behaviour_unchanged(chat_storage):
+    """Storage without content_filters must behave identically to the original."""
+    user_id = 'user1'
+    session_id = 'session1'
+    agent_id = 'agent1'
+    message = ConversationMessage(role=ParticipantRole.USER.value, content=[{'text': 'plain text'}])
+
+    saved = await chat_storage.save_chat_message(user_id, session_id, agent_id, message)
+    assert saved[0].content == [{'text': 'plain text'}]
+
+    fetched = await chat_storage.fetch_chat(user_id, session_id, agent_id)
+    assert fetched[0].content == [{'text': 'plain text'}]
 
 
 @pytest.mark.asyncio

--- a/python/src/tests/storage/test_dynamodb_chat_storage.py
+++ b/python/src/tests/storage/test_dynamodb_chat_storage.py
@@ -250,6 +250,66 @@ async def test_no_content_filters_behaviour_unchanged(chat_storage):
 
 
 @pytest.mark.asyncio
+async def test_content_filters_consecutive_message_returns_unmasked(filtered_chat_storage):
+    """
+    When a consecutive same-role message is detected, save_chat_message short-circuits
+    and returns the existing conversation without persisting the new message. That
+    early-return path must still restore original values (via _reverse_content_filters)
+    instead of leaking the raw, placeholder-masked stored content.
+    """
+    user_id = 'user1'
+    session_id = 'session1'
+    agent_id = 'agent1'
+    message1 = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{'text': 'Hello from acme-corp'}]
+    )
+    message2 = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{'text': 'Another message from acme-corp'}]
+    )
+
+    await filtered_chat_storage.save_chat_message(user_id, session_id, agent_id, message1)
+    # Second message has the same role as the last stored message, so it should be
+    # rejected and the (unmasked) existing conversation returned instead.
+    result = await filtered_chat_storage.save_chat_message(user_id, session_id, agent_id, message2)
+
+    assert len(result) == 1
+    assert result[0].content == [{'text': 'Hello from acme-corp'}]
+    # Ensure no placeholder text leaked through
+    assert '#COMPANY#' not in str(result[0].content)
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_chats_restores_non_list_content(filtered_chat_storage):
+    """
+    fetch_all_chats must reverse content filters regardless of whether the stored
+    message content is a list or a plain string. Previously, an isinstance(list)
+    guard skipped restoration for non-list content, letting masked placeholder
+    text leak into the returned chat list.
+    """
+    user_id = 'user1'
+    session_id = 'session1'
+    agent_id = 'agent1'
+    key = filtered_chat_storage._generate_key(user_id, session_id, agent_id)
+
+    filtered_chat_storage.table.put_item(Item={
+        'PK': user_id,
+        'SK': key,
+        'conversation': [
+            {'role': ParticipantRole.USER.value, 'content': 'Hello from #COMPANY#', 'timestamp': 1},
+        ],
+    })
+
+    all_chats = await filtered_chat_storage.fetch_all_chats(user_id, session_id)
+    assert len(all_chats) == 1
+    # Non-list content is wrapped into a text block by fetch_all_chats, but the
+    # placeholder must have been restored to the original value first.
+    assert all_chats[0].content == [{'text': 'Hello from acme-corp'}]
+    assert '#COMPANY#' not in str(all_chats[0].content)
+
+
+@pytest.mark.asyncio
 async def test_save_and_fetch_chat_messages_timestamp(chat_storage):
     """
     Testing saving multiple ConversationMessage at once


### PR DESCRIPTION
## Issue Link (REQUIRED)
Fixes #131

## Summary
### Changes
Adds an optional `content_filters` parameter to `DynamoDbChatStorage` — a list of `(original, placeholder)` string pairs. When provided:

- **On save** (`save_chat_message`, `save_chat_messages`): each original value is replaced by its placeholder before the message is written to DynamoDB.
- **On fetch** (`fetch_chat`, `fetch_chat_with_timestamp`, `fetch_all_chats`): placeholders are restored to their original values before returning to the caller.

This eliminates the need for a custom storage implementation when sensitive content (e.g. company names, tokens) must not be persisted in plain text.

### User experience
**Before:** users had to subclass `DynamoDbChatStorage` or write a custom storage class to mask sensitive values.

**After:**
```python
storage = DynamoDbChatStorage(
    table_name="my-table",
    region="us-east-1",
    content_filters=[
        ("acme-corp", "#COMPANY#"),
        ("secret-token-xyz", "#TOKEN#"),
    ]
)
```
DynamoDB stores `#COMPANY#`; the agent always sees `acme-corp`.

## Checklist
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.